### PR TITLE
[2.4] Change for sonatype usertoken

### DIFF
--- a/.circleci/.maven.xml
+++ b/.circleci/.maven.xml
@@ -4,8 +4,8 @@
         <server>
             <!-- Maven Central Deployment -->
             <id>ossrh</id>
-            <username>${env.SONATYPE_USERNAME}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
+            <username>${env.SONATYPE_USERTOKEN_ID}</username>
+            <password>${env.SONATYPE_USERTOKEN_TOKEN}</password>
         </server>
     </servers>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>jp.co.yahoo.yosegi</groupId>
     <artifactId>yosegi-spark_2.11</artifactId>
-    <version>2.0.2_spark-2.4-SNAPSHOT</version>
+    <version>2.0.1_spark-2.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Yosegi Spark</name>
     <description>Yosegi Spark library.</description>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Using sonatype usertoken is required for uploading maven central.
And I reverted the version because failed to upload maven central.

### How did you do the test? (Not required for updating documents)
No testing needed.