### PR TITLE
Reduce surefire heap size because it gets killed during testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <forkCount>2</forkCount>
                     <reuseForks>true</reuseForks>
-                    <argLine>@{surefireArgLine} -Xmx1536m -XX:MaxPermSize=512m</argLine>
+                    <argLine>@{surefireArgLine} -Xmx1024m -XX:MaxPermSize=512m</argLine>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
We have to reduce surefire heap size because it gets killed during testing.

### How did you do the test? (Not required for updating documents)
Not required.